### PR TITLE
fast-classifier: fixes header linking failure issue

### DIFF
--- a/package/kernel/fast-classifier/Makefile
+++ b/package/kernel/fast-classifier/Makefile
@@ -36,6 +36,7 @@ define Package/fast-classifier-example/description
 endef
 
 SFE_MAKE_OPTS:=SFE_SUPPORT_IPV6=y
+EXTRA_CFLAGS+=-I$(STAGING_DIR)/usr/include/shortcut-fe
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" $(strip $(SFE_MAKE_OPTS)) \

--- a/package/kernel/shortcut-fe/Makefile
+++ b/package/kernel/shortcut-fe/Makefile
@@ -68,15 +68,13 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/shortcut-fe
-	$(CP) -rf $(PKG_BUILD_DIR)/sfe.h $(1)/usr/include/shortcut-fe
+	$(CP) -rf $(PKG_BUILD_DIR)/*.h $(1)/usr/include/shortcut-fe
 endef
 
-#define KernelPackage/shortcut-fe/install
-#	$(INSTALL_DIR) $(1)/etc/init.d
-#	$(INSTALL_BIN) ./files/etc/init.d/shortcut-fe $(1)/etc/init.d
-#	$(INSTALL_DIR) $(1)/usr/bin
-#	$(INSTALL_BIN) ./files/usr/bin/sfe_dump $(1)/usr/bin
-#endef
+define KernelPackage/shortcut-fe/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/usr/bin/sfe_dump $(1)/usr/bin
+endef
 
 $(eval $(call KernelPackage,shortcut-fe))
 $(eval $(call KernelPackage,shortcut-fe-cm))


### PR DESCRIPTION
(cherry picked from commit efe69269efb0f4df5f402d178b93c6bf2ca58c86)