### PR TITLE
merge official

### DIFF
--- a/package/network/config/firewall/Makefile
+++ b/package/network/config/firewall/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=firewall
-PKG_RELEASE:=1
+PKG_RELEASE:=1.1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firewall3.git

--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -54,13 +54,11 @@ config rule
 	option target		ACCEPT
 
 # Allow DHCPv6 replies
-# see https://dev.openwrt.org/ticket/10381
+# see https://github.com/openwrt/openwrt/issues/5066
 config rule
 	option name		Allow-DHCPv6
 	option src		wan
 	option proto		udp
-	option src_ip		fc00::/6
-	option dest_ip		fc00::/6
 	option dest_port	546
 	option family		ipv6
 	option target		ACCEPT


### PR DESCRIPTION
Remove restrictions on source and destination addresses, which aren't
specified on RFC8415, and for some reason in openwrt are configured
to allow both link-local and ULA addresses.
As cleared out in issue #5066 there are some ISPs that use Gloabal
Unicast addresses, so fix this rule to allow them.

Fixes: #5066

Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>
[rebase onto firewall3, clarify subject, bump PKG_RELEASE]
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(backported from commit 65258f5d6093809c541050256646795bc0a460a9)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
